### PR TITLE
Enable tls using curl lib

### DIFF
--- a/lib/factomd.q
+++ b/lib/factomd.q
@@ -1,17 +1,30 @@
 \d .factomd
 
+userpassEnabled:0b
+tlsEnabled:0b
+
 
 hostLookup:`factomd`wallet!`$":http://localhost:",/:("8088/v2";"8089/v2")
 passLookup:`factomd`wallet!("";"")
+tlsLookup:`factomd`wallet!("";"")
 
 
 initHost:{[hostAddr]
-  @[`.factomd;`hostLookup;,;(!) . enlist@'(`factomd;hostAddr)];
+  @[`.factomd;`hostLookup;,;(!) . enlist@'(`factomd;hsym `$hostAddr)];
  }
 
 
-initPass:{[hostPass]
-  @[`.factomd;`passLookup;,;(!) . enlist@'(`factomd;.factomd.util[`base64Encode] hostPass)];
+initPass:{[username;password]
+  hostPass:":" sv (username;password);
+  @[`.factomd;`passLookup;,;(!) . enlist@'(`factomd;hostPass)];
+  @[`.factomd;`userpassEnabled;:;1b];
+ }
+
+
+initTLS:{[certificate]
+  @[`.factomd;`tlsLookup;,;(!) . enlist@'(`factomd;certificate)];
+  @[`.factomd;`tlsEnabled;:;1b];
+  @[`.factomd;`request;:;curlRequest];
  }
 
 
@@ -24,21 +37,21 @@ directory_block:{[keyMerkleRoot;callback]
   body:defaultPayload[];
   body[`method]:"directory-block";
   body[`params]:(enlist `KeyMR)!(enlist keyMerkleRoot);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
 directory_block_head:{[callback]
   body:defaultPayload[];
   body[`method]:"directory-block-head";
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
 heights:{[callback]
   body:defaultPayload[];
   body[`method]:"heights";
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -46,7 +59,7 @@ raw_data:{[hash;callback]
   body:defaultPayload[];
   body[`method]:"raw-data";
   body[`params]:(enlist `hash)!(enlist hash);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -54,7 +67,7 @@ dblock_by_height:{[height;callback]
   body:defaultPayload[];
   body[`method]:"dblock-by-height";
   body[`params]:(enlist `height)!(enlist height);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -62,7 +75,7 @@ ablock_by_height:{[height;callback]
   body:defaultPayload[];
   body[`method]:"ablock-by-height";
   body[`params]:(enlist `height)!(enlist height);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -70,7 +83,7 @@ ecblock_by_height:{[height;callback]
   body:defaultPayload[];
   body[`method]:"ecblock-by-height";
   body[`params]:(enlist `height)!(enlist height);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -78,7 +91,7 @@ fblock_by_height:{[height;callback]
   body:defaultPayload[];
   body[`method]:"fblock-by-height";
   body[`params]:(enlist `height)!(enlist height);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -86,7 +99,7 @@ entrycredit_block:{[keyMR;callback]
   body:defaultPayload[];
   body[`method]:"entrycredit-block";
   body[`params]:(enlist `keyMR)!(enlist keyMR);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -94,7 +107,7 @@ factoid_block:{[keyMR;callback]
   body:defaultPayload[];
   body[`method]:"factoid-block";
   body[`params]:(enlist `keyMR)!(enlist keyMR);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -102,7 +115,7 @@ receipt:{[hash;callback]
   body:defaultPayload[];
   body[`method]:"receipt";
   body[`params]:(enlist `hash)!(enlist hash);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
   }
 
 
@@ -110,7 +123,7 @@ admin_block:{[keyMR;callback]
   body:defaultPayload[];
   body[`method]:"admin-block";
   body[`params]:(enlist `keyMR)!(enlist keyMR);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -118,7 +131,7 @@ entry_block:{[keyMR;callback]
   body:defaultPayload[];
   body[`method]:"entry-block";
   body[`params]:(enlist `keyMR)!(enlist keyMR);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -126,7 +139,7 @@ entry:{[entryHash;callback]
   body:defaultPayload[];
   body[`method]:"entry";
   body[`params]:(enlist `Hash)!(enlist entryHash);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -134,7 +147,7 @@ pending_entries:{[callback]
   body:defaultPayload[];
   body[`method]:"pending-entries";
   body[`params]:()!();
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -142,7 +155,7 @@ transaction:{[transactionHash;callback]
   body:defaultPayload[];
   body[`method]:"transaction";
   body[`params]:(enlist `hash)!(enlist transactionHash);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -150,7 +163,7 @@ ack:{[hash;chainid;callback]
   body:defaultPayload[];
   body[`method]:"ack";
   body[`params]:(`hash`chainid`fulltransaction)!(hash;chainid;"");
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -158,7 +171,7 @@ pending_transactions:{[entryCreditAddress;callback]
   body:defaultPayload[];
   body[`method]:"pending-transactions";
   body[`params]:(enlist `Address)!(enlist entryCreditAddress);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -166,7 +179,7 @@ chain_head:{[chainID;callback]
   body:defaultPayload[];
   body[`method]:"chain-head";
   body[`params]:(enlist `ChainID)!(enlist chainID);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -174,7 +187,7 @@ entry_credit_balance:{[entryCreditAddress;callback]
   body:defaultPayload[];
   body[`method]:"entry-credit-balance";
   body[`params]:(enlist `address)!(enlist entryCreditAddress);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -182,20 +195,20 @@ factoid_balance:{[factoidAddress;callback]
   body:defaultPayload[];
   body[`method]:"factoid-balance";
   body[`params]:(enlist `address)!(enlist factoidAddress);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
 entry_credit_rate:{[callback]
   body:defaultPayload[];
   body[`method]:"entry-credit-rate";
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
 properties:{[callback]
   body:defaultPayload[];
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -203,7 +216,7 @@ factoid_submit:{[transactionHEX;callback]
   body:defaultPayload[];
   body[`method]:"factoid-submit";
   body[`params]:(enlist `transaction)!(enlist transactionHEX);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -211,7 +224,7 @@ commit_chain:{[commitChainHEX;callback]
   body:defaultPayload[];
   body[`method]:"commit-chain";
   body[`params]:(enlist `message)!(enlist commitChainHEX);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -219,7 +232,7 @@ reveal_chain:{[revealChainHEX;callback]
   body:defaultPayload[];
   body[`method]:"reveal-chain";
   body[`params]:(enlist `entry)!(enlist revealChainHEX);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -227,7 +240,7 @@ commit_entry:{[entryCommitHEX;callback]
   body:defaultPayload[];
   body[`method]:"commit-entry";
   body[`params]:(enlist `message)!(enlist entryCommitHEX);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 
@@ -235,7 +248,7 @@ reveal_entry:{[revealEntryHEX;callback]
   body:defaultPayload[];
   body[`method]:"reveal-entry";
   body[`params]:(enlist `entry)!(enlist revealEntryHEX);
-  callback .Q.postCmd[hostLookup[`factomd];body]
+  callback .factomd.request[hostLookup[`factomd];body]
  }
 
 

--- a/lib/factomd.q
+++ b/lib/factomd.q
@@ -37,21 +37,21 @@ directory_block:{[keyMerkleRoot;callback]
   body:defaultPayload[];
   body[`method]:"directory-block";
   body[`params]:(enlist `KeyMR)!(enlist keyMerkleRoot);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
 directory_block_head:{[callback]
   body:defaultPayload[];
   body[`method]:"directory-block-head";
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
 heights:{[callback]
   body:defaultPayload[];
   body[`method]:"heights";
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -59,7 +59,7 @@ raw_data:{[hash;callback]
   body:defaultPayload[];
   body[`method]:"raw-data";
   body[`params]:(enlist `hash)!(enlist hash);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -67,7 +67,7 @@ dblock_by_height:{[height;callback]
   body:defaultPayload[];
   body[`method]:"dblock-by-height";
   body[`params]:(enlist `height)!(enlist height);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -75,7 +75,7 @@ ablock_by_height:{[height;callback]
   body:defaultPayload[];
   body[`method]:"ablock-by-height";
   body[`params]:(enlist `height)!(enlist height);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -83,7 +83,7 @@ ecblock_by_height:{[height;callback]
   body:defaultPayload[];
   body[`method]:"ecblock-by-height";
   body[`params]:(enlist `height)!(enlist height);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -91,7 +91,7 @@ fblock_by_height:{[height;callback]
   body:defaultPayload[];
   body[`method]:"fblock-by-height";
   body[`params]:(enlist `height)!(enlist height);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -99,7 +99,7 @@ entrycredit_block:{[keyMR;callback]
   body:defaultPayload[];
   body[`method]:"entrycredit-block";
   body[`params]:(enlist `keyMR)!(enlist keyMR);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -107,7 +107,7 @@ factoid_block:{[keyMR;callback]
   body:defaultPayload[];
   body[`method]:"factoid-block";
   body[`params]:(enlist `keyMR)!(enlist keyMR);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -115,7 +115,7 @@ receipt:{[hash;callback]
   body:defaultPayload[];
   body[`method]:"receipt";
   body[`params]:(enlist `hash)!(enlist hash);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
   }
 
 
@@ -123,7 +123,7 @@ admin_block:{[keyMR;callback]
   body:defaultPayload[];
   body[`method]:"admin-block";
   body[`params]:(enlist `keyMR)!(enlist keyMR);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -131,7 +131,7 @@ entry_block:{[keyMR;callback]
   body:defaultPayload[];
   body[`method]:"entry-block";
   body[`params]:(enlist `keyMR)!(enlist keyMR);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -139,7 +139,7 @@ entry:{[entryHash;callback]
   body:defaultPayload[];
   body[`method]:"entry";
   body[`params]:(enlist `Hash)!(enlist entryHash);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -147,7 +147,7 @@ pending_entries:{[callback]
   body:defaultPayload[];
   body[`method]:"pending-entries";
   body[`params]:()!();
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -155,7 +155,7 @@ transaction:{[transactionHash;callback]
   body:defaultPayload[];
   body[`method]:"transaction";
   body[`params]:(enlist `hash)!(enlist transactionHash);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -163,7 +163,7 @@ ack:{[hash;chainid;callback]
   body:defaultPayload[];
   body[`method]:"ack";
   body[`params]:(`hash`chainid`fulltransaction)!(hash;chainid;"");
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -171,7 +171,7 @@ pending_transactions:{[entryCreditAddress;callback]
   body:defaultPayload[];
   body[`method]:"pending-transactions";
   body[`params]:(enlist `Address)!(enlist entryCreditAddress);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -179,7 +179,7 @@ chain_head:{[chainID;callback]
   body:defaultPayload[];
   body[`method]:"chain-head";
   body[`params]:(enlist `ChainID)!(enlist chainID);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -187,7 +187,7 @@ entry_credit_balance:{[entryCreditAddress;callback]
   body:defaultPayload[];
   body[`method]:"entry-credit-balance";
   body[`params]:(enlist `address)!(enlist entryCreditAddress);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -195,20 +195,20 @@ factoid_balance:{[factoidAddress;callback]
   body:defaultPayload[];
   body[`method]:"factoid-balance";
   body[`params]:(enlist `address)!(enlist factoidAddress);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
 entry_credit_rate:{[callback]
   body:defaultPayload[];
   body[`method]:"entry-credit-rate";
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
 properties:{[callback]
   body:defaultPayload[];
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -216,7 +216,7 @@ factoid_submit:{[transactionHEX;callback]
   body:defaultPayload[];
   body[`method]:"factoid-submit";
   body[`params]:(enlist `transaction)!(enlist transactionHEX);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -224,7 +224,7 @@ commit_chain:{[commitChainHEX;callback]
   body:defaultPayload[];
   body[`method]:"commit-chain";
   body[`params]:(enlist `message)!(enlist commitChainHEX);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -232,7 +232,7 @@ reveal_chain:{[revealChainHEX;callback]
   body:defaultPayload[];
   body[`method]:"reveal-chain";
   body[`params]:(enlist `entry)!(enlist revealChainHEX);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -240,7 +240,7 @@ commit_entry:{[entryCommitHEX;callback]
   body:defaultPayload[];
   body[`method]:"commit-entry";
   body[`params]:(enlist `message)!(enlist entryCommitHEX);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 
@@ -248,7 +248,7 @@ reveal_entry:{[revealEntryHEX;callback]
   body:defaultPayload[];
   body[`method]:"reveal-entry";
   body[`params]:(enlist `entry)!(enlist revealEntryHEX);
-  callback .factomd.request[hostLookup[`factomd];body]
+  callback .factomd.request[`factomd;body]
  }
 
 

--- a/lib/factomwallet.q
+++ b/lib/factomwallet.q
@@ -1,13 +1,17 @@
 \d .factomwallet
 
+userpassEnabled:0b
+tlsEnabled:0b
+
 
 initHost:{[hostAddr]
-  @[`.factomd;`hostLookup;,;(!) . enlist@'(`wallet;hostAddr)];
+  @[`.factomd;`hostLookup;,;(!) . enlist@'(`wallet;hsym `$hostAddr)];
  }
 
-
-initPass:{[hostPass]
+initPass:{[username;password]
+  hostPass:":" sv (username;password);
   @[`.factomd;`passLookup;,;(!) . enlist@'(`wallet;.factomd.util[`base64Encode] hostPass)];
+  @[`.factomd;`userpassEnabled;:;1b];
  }
 
 
@@ -23,7 +27,7 @@ address:{[factoidAddress;callback]
   body:defaultPayload[];
   body[`method]:"address";
   body[`params]:(enlist `address)!(enlist factoidAddress);
-  callback .Q.getCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -31,7 +35,7 @@ all_addresses:{[callback]
   body:defaultPayload[];
   body[`method]:"all-addresses";
   body[`params]:"";
-  callback .Q.getCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -39,7 +43,7 @@ generate_ec_address:{[callback]
   body:defaultPayload[];
   body[`method]:"generate-ec-address";
   body[`params]:"";
-  callback .Q.getCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -47,7 +51,7 @@ generate_factoid_address:{[callback]
   body:defaultPayload[];
   body[`method]:"generate-factoid-address";
   body[`params]:"";
-  callback .Q.getCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -55,7 +59,7 @@ get_height:{[callback]
   body:defaultPayload[];
   body[`method]:"get-height";
   body[`params]:"";
-  callback .Q.getCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -68,7 +72,7 @@ import_addresses:{[privateAddresses;callback]
   if[0h~type privateAddresses; 
     body[`params]:(enlist `addresses)!enlist ({(enlist `secret)!(enlist x)} each privateAddresses);
   ];
-  callback .Q.getCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -76,7 +80,7 @@ import_koinify:{[passPhrase;callback]
   body:defaultPayload[];
   body[`method]:"import-koinify";
   body[`params]:(enlist `words)!(enlist passPhrase);
-  callback .Q.getCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -84,7 +88,7 @@ wallet_backup:{[callback]
   body:defaultPayload[];
   body[`method]:"wallet-backup";
   body[`params]:"";
-  callback .Q.getCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -92,7 +96,7 @@ tmp_transactions:{[callback]
   body:defaultPayload[];
   body[`method]:"tmp-transactions";
   body[`params]:"";
-  callback .Q.postCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -100,7 +104,7 @@ delete_transaction:{[transactionName;callback]
   body:defaultPayload[];
   body[`method]:"delete-transaction";
   body[`params]:(enlist `$"tx-name")!(enlist transactionName);
-  callback .Q.getCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -108,7 +112,7 @@ new_transaction:{[transactionName;callback]
   body:defaultPayload[];
   body[`method]:"new-transaction";
   body[`params]:(enlist `$"tx-name")!(enlist transactionName);
-  callback .Q.getCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -116,7 +120,7 @@ add_input:{[transactionName;publicAddress;numFactoshis;callback]
   body:defaultPayload[];
   body[`method]:"add-input";
   body[`params]:(`$"tx-name";`address;`amount)!(transactionName;publicAddress;numFactoshis);
-  callback .Q.postCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -124,7 +128,7 @@ add_output:{[transactionName;factoidAddress;numFactoshis;callback]
   body:defaultPayload[];
   body[`method]:"add-output";
   body[`params]:(`$"tx-name";`address;`amount)!(transactionName;factoidAddress;numFactoshis);
-  callback .Q.postCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -132,7 +136,7 @@ add_ec_output:{[transactionName;entryCreditAddress;numFactoshis;callback]
   body:defaultPayload[];
   body[`method]:"add-ec-output";
   body[`params]:(`$"tx-name";`address;`amount)!(transactionName;entryCreditAddress;numFactoshis);
-  callback .Q.postCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -140,7 +144,7 @@ add_fee:{[transactionName;factoidAddress;callback]
   body:defaultPayload[];
   body[`method]:"add-fee";
   body[`params]:(`$"tx-name";`address)!(transactionName;factoidAddress);
-  callback .Q.postCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -148,7 +152,7 @@ sub_fee:{[transactionName;factoidAddress;callback]
   body:defaultPayload[];
   body[`method]:"sub-fee";
   body[`params]:(`$"tx-name";`address)!(transactionName;factoidAddress);
-  callback .Q.postCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -156,7 +160,7 @@ sign_transaction:{[transactionName;callback]
   body:defaultPayload[];
   body[`method]:"sign-transaction";
   body[`params]:(enlist `$"tx-name")!(enlist transactionName);
-  callback .Q.postCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -164,7 +168,7 @@ compose_transaction:{[transactionName;callback]
   body:defaultPayload[];
   body[`method]:"compose-transaction";
   body[`params]:(enlist `$"tx-name")!(enlist transactionName);
-  callback .Q.postCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -177,7 +181,7 @@ compose_chain:{[entryCreditAddress;exTids;Content;callback]
   firstEntry:` _firstEntry;
   chain:(enlist `firstentry)!enlist firstEntry;
   body[`params]:`chain`ecpub!(chain;entryCreditAddress);
-  callback .Q.postCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -190,7 +194,7 @@ compose_entry:{[entryCreditAddress;exTids;Content;chainID;callback]
   entry[`content]:Content;
   entry:` _entry;
   body[`params]:`entry`ecpub!(entry;entryCreditAddress);
-  callback .Q.postCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 
@@ -278,7 +282,7 @@ append_factom_chain:{[entryCreditAddress;externalIDStringList;contentString;chai
   
 properties:{[callback]
   body:defaultPayload[];
-  callback .Q.getCmd[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[.factomd.hostLookup[`wallet];body]
  }
 
 \d .

--- a/lib/factomwallet.q
+++ b/lib/factomwallet.q
@@ -197,7 +197,7 @@ compose_entry:{[entryCreditAddress;exTids;Content;chainID;callback]
 checkTransError:{[output]
   $[`error in key output;
     [
-     -2 "Transaction Error: ",(string output[`error][`code])," ", raze value (`code _ output[`error]);
+     -2 "Transaction Error: ",(string output[`error][`code])," "," " sv value (`code _ output[`error]);
      :1b
     ];
    :0b

--- a/lib/factomwallet.q
+++ b/lib/factomwallet.q
@@ -27,7 +27,7 @@ address:{[factoidAddress;callback]
   body:defaultPayload[];
   body[`method]:"address";
   body[`params]:(enlist `address)!(enlist factoidAddress);
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -35,7 +35,7 @@ all_addresses:{[callback]
   body:defaultPayload[];
   body[`method]:"all-addresses";
   body[`params]:"";
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -43,7 +43,7 @@ generate_ec_address:{[callback]
   body:defaultPayload[];
   body[`method]:"generate-ec-address";
   body[`params]:"";
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -51,7 +51,7 @@ generate_factoid_address:{[callback]
   body:defaultPayload[];
   body[`method]:"generate-factoid-address";
   body[`params]:"";
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -59,7 +59,7 @@ get_height:{[callback]
   body:defaultPayload[];
   body[`method]:"get-height";
   body[`params]:"";
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -72,7 +72,7 @@ import_addresses:{[privateAddresses;callback]
   if[0h~type privateAddresses; 
     body[`params]:(enlist `addresses)!enlist ({(enlist `secret)!(enlist x)} each privateAddresses);
   ];
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -80,7 +80,7 @@ import_koinify:{[passPhrase;callback]
   body:defaultPayload[];
   body[`method]:"import-koinify";
   body[`params]:(enlist `words)!(enlist passPhrase);
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -88,7 +88,7 @@ wallet_backup:{[callback]
   body:defaultPayload[];
   body[`method]:"wallet-backup";
   body[`params]:"";
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -96,7 +96,7 @@ tmp_transactions:{[callback]
   body:defaultPayload[];
   body[`method]:"tmp-transactions";
   body[`params]:"";
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -104,7 +104,7 @@ delete_transaction:{[transactionName;callback]
   body:defaultPayload[];
   body[`method]:"delete-transaction";
   body[`params]:(enlist `$"tx-name")!(enlist transactionName);
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -112,7 +112,7 @@ new_transaction:{[transactionName;callback]
   body:defaultPayload[];
   body[`method]:"new-transaction";
   body[`params]:(enlist `$"tx-name")!(enlist transactionName);
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -120,7 +120,7 @@ add_input:{[transactionName;publicAddress;numFactoshis;callback]
   body:defaultPayload[];
   body[`method]:"add-input";
   body[`params]:(`$"tx-name";`address;`amount)!(transactionName;publicAddress;numFactoshis);
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -128,7 +128,7 @@ add_output:{[transactionName;factoidAddress;numFactoshis;callback]
   body:defaultPayload[];
   body[`method]:"add-output";
   body[`params]:(`$"tx-name";`address;`amount)!(transactionName;factoidAddress;numFactoshis);
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -136,7 +136,7 @@ add_ec_output:{[transactionName;entryCreditAddress;numFactoshis;callback]
   body:defaultPayload[];
   body[`method]:"add-ec-output";
   body[`params]:(`$"tx-name";`address;`amount)!(transactionName;entryCreditAddress;numFactoshis);
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -144,7 +144,7 @@ add_fee:{[transactionName;factoidAddress;callback]
   body:defaultPayload[];
   body[`method]:"add-fee";
   body[`params]:(`$"tx-name";`address)!(transactionName;factoidAddress);
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -152,7 +152,7 @@ sub_fee:{[transactionName;factoidAddress;callback]
   body:defaultPayload[];
   body[`method]:"sub-fee";
   body[`params]:(`$"tx-name";`address)!(transactionName;factoidAddress);
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -160,7 +160,7 @@ sign_transaction:{[transactionName;callback]
   body:defaultPayload[];
   body[`method]:"sign-transaction";
   body[`params]:(enlist `$"tx-name")!(enlist transactionName);
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -168,7 +168,7 @@ compose_transaction:{[transactionName;callback]
   body:defaultPayload[];
   body[`method]:"compose-transaction";
   body[`params]:(enlist `$"tx-name")!(enlist transactionName);
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -181,7 +181,7 @@ compose_chain:{[entryCreditAddress;exTids;Content;callback]
   firstEntry:` _firstEntry;
   chain:(enlist `firstentry)!enlist firstEntry;
   body[`params]:`chain`ecpub!(chain;entryCreditAddress);
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -194,7 +194,7 @@ compose_entry:{[entryCreditAddress;exTids;Content;chainID;callback]
   entry[`content]:Content;
   entry:` _entry;
   body[`params]:`entry`ecpub!(entry;entryCreditAddress);
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 
@@ -282,7 +282,7 @@ append_factom_chain:{[entryCreditAddress;externalIDStringList;contentString;chai
   
 properties:{[callback]
   body:defaultPayload[];
-  callback .factomd.request[.factomd.hostLookup[`wallet];body]
+  callback .factomd.request[`wallet;body]
  }
 
 \d .

--- a/lib/init.q
+++ b/lib/init.q
@@ -1,5 +1,5 @@
 .utl.require .utl.PKGLOADING,"/q.k"
-.utl.require .utl.PKGLOADING,"/requests.q"
 .utl.require .utl.PKGLOADING,"/utilities.q"
+.utl.require .utl.PKGLOADING,"/requests.q"
 .utl.require .utl.PKGLOADING,"/factomd.q"
 .utl.require .utl.PKGLOADING,"/factomwallet.q"

--- a/lib/init.q
+++ b/lib/init.q
@@ -1,5 +1,5 @@
 .utl.require .utl.PKGLOADING,"/q.k"
-.utl.require .utl.PKGLOADING,"/utilities.q"
 .utl.require .utl.PKGLOADING,"/requests.q"
+.utl.require .utl.PKGLOADING,"/utilities.q"
 .utl.require .utl.PKGLOADING,"/factomd.q"
 .utl.require .utl.PKGLOADING,"/factomwallet.q"

--- a/lib/requests.q
+++ b/lib/requests.q
@@ -4,19 +4,24 @@ curlLibPath:hsym `$getenv[`QFACTOM_HOME],"/utils/curlLib";
 curl:curlLibPath 2:(`request;5)
 
 
-qRequest:{[hostName;body]
-  credentials:.factomd.util[`base64Encode] .factomd.passLookup[.factomd.hostLookup?hostName];
-  out:@[.Q.hpfact[hostName;"Authorization: Basic ",credentials,";Content-Type: text/plain"];.j.j body;{[err] -2 "Error: qRequest: ",err;:"{}"}];
+qRequest:{[serviceName;body]
+  hostName:.factomd.hostLookup[serviceName];
+  credentials:.factomd.util[`base64Encode] .factomd.passLookup[serviceName];
+  header:";Content-Type: text/plain";
+
+  out:@[.Q.hpfact[hostName;"Authorization: Basic ",credentials,",header];.j.j body;{[err] -2 "Error: qRequest: ",err;:"{}"}];
   @[.j.k;;{[out;err] -2 "Error: ",err," .Q.hpfact returned: ",out}[out;]] out 
  }
 
-curlRequest:{[hostName;body]
-   serviceName:.factomd.hostLookup?hostName;   
+curlRequest:{[serviceName;body]
+   hostName:.factomd.hostLookup[serviceName];
+   credentials:`$.factomd.passLookup[serviceName];
    header:`$"Content-Type: text/plain";
+
    body:`$.j.j body;
    tlsCert:`$.factomd.tlsLookup[serviceName];
    host:$[`~tlsCert;`$1 _string[hostName];`$1 _ssr[string[hostName];"http";"https"]];
-   credentials:`$.factomd.passLookup[serviceName];
+
    out:@[.factomd.curl[host;body;header;tlsCert;];credentials;{[err] -2 "Error: curlRequest: ",err;:"{}"}];
    @[.j.k;;{[out;err] -2 "Error: ",err," curl returned: ",out}[out;]] out
  }

--- a/lib/requests.q
+++ b/lib/requests.q
@@ -9,7 +9,7 @@ qRequest:{[serviceName;body]
   credentials:.factomd.util[`base64Encode] .factomd.passLookup[serviceName];
   header:";Content-Type: text/plain";
 
-  out:@[.Q.hpfact[hostName;"Authorization: Basic ",credentials,",header];.j.j body;{[err] -2 "Error: qRequest: ",err;:"{}"}];
+  out:@[.Q.hpfact[hostName;"Authorization: Basic ",credentials," ",header];.j.j body;{[err] -2 "Error: qRequest: ",err;:"{}"}];
   @[.j.k;;{[out;err] -2 "Error: ",err," .Q.hpfact returned: ",out}[out;]] out 
  }
 

--- a/lib/requests.q
+++ b/lib/requests.q
@@ -1,15 +1,25 @@
-\d .Q
+\d .factomd
 
-getCmd:{[hostName;body]
-  credentials:.factomd.passLookup[.factomd.hostLookup?hostName];
-  out:@[.Q.hgfact[hostName;"Authorization: Basic ",credentials,";Content-Type: text/plain"];.j.j body;{[err] -2 "Error: getCmd: ",err;:"{}"}];
-  @[.j.k;;{[out;err] -2 "Error: ",err," .Q.hg returned: ",out}[out;]] out 
- }
+curlLibPath:hsym `$getenv[`QFACTOM_HOME],"/utils/curlLib";
+curl:curlLibPath 2:(`request;5)
 
-postCmd:{[hostName;body]
-  credentials:.factomd.passLookup[.factomd.hostLookup?hostName];
+
+qRequest:{[hostName;body]
+  credentials:.factomd.util[`base64Encode] .factomd.passLookup[.factomd.hostLookup?hostName];
   out:@[.Q.hpfact[hostName;"Authorization: Basic ",credentials,";Content-Type: text/plain"];.j.j body;{[err] -2 "Error: postCmd: ",err;:"{}"}];
   @[.j.k;;{[out;err] -2 "Error: ",err," .Q.hp returned: ",out}[out;]] out 
  }
 
+curlRequest:{[hostName;body]
+   serviceName:.factomd.hostLookup?hostName;   
+   header:`$"Content-Type: text/plain";
+   body:`$.j.j body;
+   tlsCert:`$.factomd.tlsLookup[serviceName];
+   host:$[`~tlsCert;`$1 _string[hostName];`$1 _ssr[string[hostName];"http";"https"]];
+   userpass:`$.factomd.passLookup[serviceName];
+   out:@[.factomd.curl[host;body;header;tlsCert;];userpass;{[err] -2 "Error: curlRequest: ",err;:"{}"}];
+   @[.j.k;;{[out;err] -2 "Error: ",err," .Q.hp returned: ",out}[out;]] out
+ }
+
+request:qRequest
 \d .

--- a/lib/requests.q
+++ b/lib/requests.q
@@ -6,8 +6,8 @@ curl:curlLibPath 2:(`request;5)
 
 qRequest:{[hostName;body]
   credentials:.factomd.util[`base64Encode] .factomd.passLookup[.factomd.hostLookup?hostName];
-  out:@[.Q.hpfact[hostName;"Authorization: Basic ",credentials,";Content-Type: text/plain"];.j.j body;{[err] -2 "Error: postCmd: ",err;:"{}"}];
-  @[.j.k;;{[out;err] -2 "Error: ",err," .Q.hp returned: ",out}[out;]] out 
+  out:@[.Q.hpfact[hostName;"Authorization: Basic ",credentials,";Content-Type: text/plain"];.j.j body;{[err] -2 "Error: qRequest: ",err;:"{}"}];
+  @[.j.k;;{[out;err] -2 "Error: ",err," .Q.hpfact returned: ",out}[out;]] out 
  }
 
 curlRequest:{[hostName;body]
@@ -16,9 +16,9 @@ curlRequest:{[hostName;body]
    body:`$.j.j body;
    tlsCert:`$.factomd.tlsLookup[serviceName];
    host:$[`~tlsCert;`$1 _string[hostName];`$1 _ssr[string[hostName];"http";"https"]];
-   userpass:`$.factomd.passLookup[serviceName];
-   out:@[.factomd.curl[host;body;header;tlsCert;];userpass;{[err] -2 "Error: curlRequest: ",err;:"{}"}];
-   @[.j.k;;{[out;err] -2 "Error: ",err," .Q.hp returned: ",out}[out;]] out
+   credentials:`$.factomd.passLookup[serviceName];
+   out:@[.factomd.curl[host;body;header;tlsCert;];credentials;{[err] -2 "Error: curlRequest: ",err;:"{}"}];
+   @[.j.k;;{[out;err] -2 "Error: ",err," curl returned: ",out}[out;]] out
  }
 
 request:qRequest

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -19,15 +19,19 @@ else
    OBJHOME=l32
 endif
 
-all : cryptoLib
+all : cryptoLib curlLib
 CC=gcc
-OPTS=-D KXVER=3 -Wall -fno-strict-aliasing -Wno-parentheses -Wno-pointer-sign -g -O2
+OPTS=-D KXVER=3 -Wall -fno-strict-aliasing -Wno-parentheses -g -O2
 LDOPTS=-lpthread
 CRYPTOPTS=-lcrypto -lssl
+CURLOPTS=-lcurl
 OBJ=$(OBJHOME)/c.o
 
 cryptoLib:
 	$(CC) $(CFLAG) $(OPTS) -shared -fPIC -o cryptoLib.so cryptoLib.c $(LDOPTS) $(CRYPTOPTS)
 
+curlLib:
+	$(CC) $(CFLAG) $(OPTS) -shared -fPIC -o curlLib.so curlLib.c $(LDOPTS) $(CURLOPTS)
+
 clean:
-	rm cryptoLib.so
+	rm cryptoLib.so curlLib.so

--- a/utils/cryptoLib.c
+++ b/utils/cryptoLib.c
@@ -5,36 +5,39 @@
 #include <openssl/sha.h>
 #include "k.h"
 
-K Sha256(K inputBytes) {
-  K outputHash;
-  if(KG != inputBytes->t)
-    return krr("type");
-  outputHash= ktn(KG, SHA256_DIGEST_LENGTH);
-  SHA256(kG(inputBytes), inputBytes->n, kG(outputHash));
-  return outputHash;
+K Sha256(K inputBytes)
+{
+    K outputHash;
+    if(KG != inputBytes->t)
+        return krr("type");
+    outputHash= ktn(KG, SHA256_DIGEST_LENGTH);
+    SHA256(kG(inputBytes), inputBytes->n, kG(outputHash));
+    return outputHash;
 }
 
-K Sha512(K inputBytes) {
-  K outputHash;
-  if(KG != inputBytes->t)
-    return krr("type");
-  outputHash= ktn(KG, SHA512_DIGEST_LENGTH);
-  SHA512(kG(inputBytes), inputBytes->n, kG(outputHash));
-  return outputHash;
+K Sha512(K inputBytes)
+{
+    K outputHash;
+    if(KG != inputBytes->t)
+        return krr("type");
+    outputHash= ktn(KG, SHA512_DIGEST_LENGTH);
+    SHA512(kG(inputBytes), inputBytes->n, kG(outputHash));
+    return outputHash;
 }
 
 
-K decodeToBytes(K inputString){
-  if(KC != inputString->t)
-    return krr("type");
-  size_t i = 0;
-  int outputByteLength=64;
-  const char *p = kG(inputString);
-  K outputHash = ktn(KG, outputByteLength);
+K decodeToBytes(K inputString)
+{
+    if(KC != inputString->t)
+        return krr("type");
+    size_t i = 0;
+    int outputByteLength=64;
+    const unsigned char *p = kG(inputString);
+    K outputHash = ktn(KG, outputByteLength);
 
-  for(i=0;i<outputByteLength;i++){
-    sscanf(p,"%2hhx",&kG(outputHash)[i]);
-    p+=2;
-  }
-  return outputHash;
+    for(i=0; i<outputByteLength; i++) {
+        sscanf((char *)p,"%2hhx",&kG(outputHash)[i]);
+        p+=2;
+    }
+    return outputHash;
 }

--- a/utils/curlLib.c
+++ b/utils/curlLib.c
@@ -1,0 +1,84 @@
+#define KXVER 3
+#include <string.h>
+#include <stdlib.h>
+#include <curl/curl.h>
+#include "k.h"
+
+struct string {
+    char *ptr;
+    size_t length;
+};
+
+int initString(struct string *s)
+{
+    s->length = 0;
+    s->ptr = malloc(s->length+1);
+    if (s->ptr == NULL) 
+        return 1;
+    s->ptr[0] = '\0';
+    return 0;
+}
+
+size_t writeFunc(void *buffer, size_t size, size_t nmemb, struct string *s)
+{
+    size_t new_len = s->length + size*nmemb;
+    s->ptr = realloc(s->ptr, new_len+1);
+    if (s->ptr == NULL)
+        return 0;
+
+    memcpy(s->ptr+s->length, buffer, size*nmemb);
+    s->ptr[new_len] = '\0';
+    s->length = new_len;
+    return size*nmemb;
+}
+
+K request(K url, K params, K header, K tlsCert, K userPass)
+{
+    char error[CURL_ERROR_SIZE];
+    char *hdr;
+    struct string s;
+    CURL *curl;
+
+    // Return type error to q process if input args are not all symbols
+    if(url->t != -KS || params->t != -KS || header->t != -KS || tlsCert->t != -KS) 
+        return krr("Error curl: type");
+
+    if(initString(&s))
+        return krr("Error curl: malloc failed");
+
+    hdr = strtok(header->s, ";");
+
+    if(!(curl=curl_easy_init()))
+        return krr("Error curl: easy_init");
+
+    struct curl_slist *chunk = NULL;
+    while(hdr!=NULL) {
+        chunk = curl_slist_append(chunk, hdr);
+        hdr = strtok(NULL, ";");
+    }
+
+    // If tlsCert argument is not a null symbol, enable TLS
+    if(0 != strlen(tlsCert->s)) 
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
+        curl_easy_setopt(curl, CURLOPT_CAINFO,        tlsCert->s);
+
+    // If userPass argument is not a null symbol, enable username password authentication
+    if(0 != strlen(userPass->s)) 
+        curl_easy_setopt(curl, CURLOPT_USERPWD,   userPass->s);
+
+    curl_easy_setopt(curl, CURLOPT_URL,           url->s);
+    curl_easy_setopt(curl, CURLOPT_ERRORBUFFER,   error);
+
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS,    params->s);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER,    chunk);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeFunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA,     &s);
+
+    if(CURLE_OK!=curl_easy_perform(curl))
+        return krr(error);
+
+    curl_easy_cleanup(curl);
+    curl_slist_free_all(chunk);
+    return kp(s.ptr);
+}

--- a/utils/curlLib.c
+++ b/utils/curlLib.c
@@ -40,7 +40,7 @@ K request(K url, K params, K header, K tlsCert, K userPass)
     CURL *curl;
 
     // Return type error to q process if input args are not all symbols
-    if(url->t != -KS || params->t != -KS || header->t != -KS || tlsCert->t != -KS) 
+    if(url->t != -KS || params->t != -KS || header->t != -KS || tlsCert->t != -KS || userPass->t != -KS) 
         return krr("Error curl: type");
 
     if(initString(&s))
@@ -57,11 +57,15 @@ K request(K url, K params, K header, K tlsCert, K userPass)
         hdr = strtok(NULL, ";");
     }
 
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
     // If tlsCert argument is not a null symbol, enable TLS
-    if(0 != strlen(tlsCert->s)) 
+
+    if(0 != strlen(tlsCert->s)){
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
         curl_easy_setopt(curl, CURLOPT_CAINFO,        tlsCert->s);
+    }
 
     // If userPass argument is not a null symbol, enable username password authentication
     if(0 != strlen(userPass->s)) 


### PR DESCRIPTION
The factomd client has the ability to startup with two security modes, the first is username and password authentication and the second is TLS. For the first, I was able to hack the already modified .Q.hp function to pass in the username/password credentials but such hacking is not possible to cater for TLS support. The solutions is to use to load a function from a shared C library which utilizes libcurl. For the time being, I have kept the previous request function as the default. Only when the user sets a TLS cert file path will the .factomd.request function be set to use curl. A Makefile has been added to generate the shared object, and some refactoring has also taken place in factomd.q and factomwallet.q.